### PR TITLE
Limit chromatic builds

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,8 +1,11 @@
 # Workflow name
 name: 'Chromatic'
 
-# Event for the workflow
-on: push
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 # List of jobs
 jobs:


### PR DESCRIPTION
We are really quick reaching the snapshot limit. I suggest to limit the builds to not run on every commit on every branch. but only on PRs and main branches